### PR TITLE
Rename project from CodeHephaestus to Solomon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # --- Branding ---
-BOT_DISPLAY_NAME=CodeHephaestus
+BOT_DISPLAY_NAME=Solomon
 
 # --- Tracker ---
 TASK_TRACKER=jira                          # "jira" or "linear"
@@ -9,7 +9,7 @@ TRACKER_PROJECT=PROJ
 
 # --- Status Mapping (Jira) ---
 JIRA_EMAIL=you@org.com
-JIRA_PLANNING_LABEL=codehephaestus
+JIRA_PLANNING_LABEL=solomon
 JIRA_APPROVAL_LABEL=approved
 JIRA_STATUS_TODO=To Do
 JIRA_STATUS_IN_PROGRESS=In Progress
@@ -62,7 +62,7 @@ POLL_INTERVAL=120
 MAX_ITERATIONS=0                           # 0 = infinite
 TARGET_REPO_PATH=.
 # WORKTREE_PATH=                           # Default: {TARGET_REPO_PATH}/.worktrees/
-# STATE_DB_PATH=                           # Default: {TARGET_REPO_PATH}/.codehephaestus/state.db
+# STATE_DB_PATH=                           # Default: {TARGET_REPO_PATH}/.solomon/state.db
 
 # --- Logging ---
 LOG_LEVEL=info

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env
 *.log
 .worktrees/
-.codehephaestus/
-codehephaestus
+.solomon/
+solomon

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 CodeHephaestus
+Copyright (c) 2025 Solomon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="assets/banner.png" alt="CodeHephaestus" width="700">
+  <img src="assets/banner.png" alt="Solomon" width="700">
 </p>
 
-# CodeHephaestus
+# Solomon
 
 Autonomous coding agent that picks up tracker issues, runs an interactive planning conversation, implements with a multi-agent team, and creates GitHub PRs — powered by [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) agent teams.
 
@@ -22,19 +22,19 @@ Autonomous coding agent that picks up tracker issues, runs an interactive planni
 ## Install
 
 ```bash
-go build -o codehephaestus ./cmd/codehephaestus
+go build -o solomon ./cmd/solomon
 cp .env.example .env  # fill in your credentials
 ```
 
 ## Usage
 
 ```
-./codehephaestus                       # Run continuously
-./codehephaestus --once                # Single iteration
-./codehephaestus --dry-run             # Show what would be done
-./codehephaestus --verbose             # Debug logging
-./codehephaestus --max-iterations 5    # Limit to N iterations
-./codehephaestus --config path/.env    # Custom .env file path
+./solomon                       # Run continuously
+./solomon --once                # Single iteration
+./solomon --dry-run             # Show what would be done
+./solomon --verbose             # Debug logging
+./solomon --max-iterations 5    # Limit to N iterations
+./solomon --config path/.env    # Custom .env file path
 ```
 
 ## Configuration
@@ -50,9 +50,9 @@ Key variables:
 | `TRACKER_BASE_URL` | Jira instance URL (e.g. `https://org.atlassian.net`) |
 | `TRACKER_PROJECT` | Jira project key |
 | `JIRA_EMAIL` | Email for Jira basic auth |
-| `JIRA_PLANNING_LABEL` | Label that marks issues for planning (default: `codehephaestus`) |
+| `JIRA_PLANNING_LABEL` | Label that marks issues for planning (default: `solomon`) |
 | `JIRA_APPROVAL_LABEL` | Label to signal planning approval (default: `approved`) |
-| `BOT_DISPLAY_NAME` | Name used in comments and PRs (default: `CodeHephaestus`) |
+| `BOT_DISPLAY_NAME` | Name used in comments and PRs (default: `Solomon`) |
 | `PLANNING_MODEL` | Model for planning conversations (default: `sonnet`) |
 | `TEAM_LEAD_MODEL` | Model for the team lead (default: `opus`) |
 | `FIGMA_ACCESS_TOKEN` | Optional — enables Figma design extraction |

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pixxle/codehephaestus
+module github.com/pixxle/solomon
 
 go 1.26
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,13 +102,13 @@ func Load(envPath string) (*Config, error) {
 	}
 
 	cfg := &Config{
-		BotDisplayName: envOrDefault("BOT_DISPLAY_NAME", "CodeHephaestus"),
+		BotDisplayName: envOrDefault("BOT_DISPLAY_NAME", "Solomon"),
 
 		TaskTracker:       TrackerType(envOrDefault("TASK_TRACKER", "jira")),
 		TrackerAPIKey:     os.Getenv("TRACKER_API_KEY"),
 		TrackerBaseURL:    os.Getenv("TRACKER_BASE_URL"),
 		TrackerProject:    os.Getenv("TRACKER_PROJECT"),
-		JiraPlanningLabel: envOrDefault("JIRA_PLANNING_LABEL", "codehephaestus"),
+		JiraPlanningLabel: envOrDefault("JIRA_PLANNING_LABEL", "solomon"),
 		JiraApprovalLabel: envOrDefault("JIRA_APPROVAL_LABEL", "approved"),
 		JiraEmail:         os.Getenv("JIRA_EMAIL"),
 
@@ -162,7 +162,7 @@ func Load(envPath string) (*Config, error) {
 	}
 
 	if cfg.StateDBPath == "" {
-		cfg.StateDBPath = cfg.TargetRepoPath + "/.codehephaestus/state.db"
+		cfg.StateDBPath = cfg.TargetRepoPath + "/.solomon/state.db"
 	}
 
 	if err := cfg.validate(); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,7 +10,7 @@ func TestBotSlug(t *testing.T) {
 		displayName string
 		want        string
 	}{
-		{"CodeHephaestus", "codehephaestus"},
+		{"Solomon", "solomon"},
 		{"My Cool Bot", "my-cool-bot"},
 		{"Bot 2.0!", "bot-20"},
 		{"UPPER CASE", "upper-case"},
@@ -186,11 +186,11 @@ func TestLoad_Defaults(t *testing.T) {
 		t.Fatalf("Load() error = %v", err)
 	}
 
-	if cfg.BotDisplayName != "CodeHephaestus" {
-		t.Errorf("BotDisplayName = %q, want %q", cfg.BotDisplayName, "CodeHephaestus")
+	if cfg.BotDisplayName != "Solomon" {
+		t.Errorf("BotDisplayName = %q, want %q", cfg.BotDisplayName, "Solomon")
 	}
-	if cfg.JiraPlanningLabel != "codehephaestus" {
-		t.Errorf("JiraPlanningLabel = %q, want %q", cfg.JiraPlanningLabel, "codehephaestus")
+	if cfg.JiraPlanningLabel != "solomon" {
+		t.Errorf("JiraPlanningLabel = %q, want %q", cfg.JiraPlanningLabel, "solomon")
 	}
 	if cfg.JiraApprovalLabel != "approved" {
 		t.Errorf("JiraApprovalLabel = %q, want %q", cfg.JiraApprovalLabel, "approved")

--- a/internal/guardrails/jailbreak.go
+++ b/internal/guardrails/jailbreak.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/pixxle/codehephaestus/internal/worker"
+	"github.com/pixxle/solomon/internal/worker"
 )
 
 // ScanResult holds the result of a jailbreak scan.

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/pixxle/codehephaestus/internal/config"
-	"github.com/pixxle/codehephaestus/internal/db"
-	"github.com/pixxle/codehephaestus/internal/figma"
-	"github.com/pixxle/codehephaestus/internal/git"
-	ghclient "github.com/pixxle/codehephaestus/internal/github"
-	"github.com/pixxle/codehephaestus/internal/slack"
-	"github.com/pixxle/codehephaestus/internal/statemachine"
-	"github.com/pixxle/codehephaestus/internal/tracker"
+	"github.com/pixxle/solomon/internal/config"
+	"github.com/pixxle/solomon/internal/db"
+	"github.com/pixxle/solomon/internal/figma"
+	"github.com/pixxle/solomon/internal/git"
+	ghclient "github.com/pixxle/solomon/internal/github"
+	"github.com/pixxle/solomon/internal/slack"
+	"github.com/pixxle/solomon/internal/statemachine"
+	"github.com/pixxle/solomon/internal/tracker"
 )
 
 type Runner struct {

--- a/internal/loop/prevention.go
+++ b/internal/loop/prevention.go
@@ -3,7 +3,7 @@ package loop
 import (
 	"time"
 
-	"github.com/pixxle/codehephaestus/internal/db"
+	"github.com/pixxle/solomon/internal/db"
 )
 
 const (

--- a/internal/loop/priorities.go
+++ b/internal/loop/priorities.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/pixxle/codehephaestus/internal/config"
-	"github.com/pixxle/codehephaestus/internal/db"
-	"github.com/pixxle/codehephaestus/internal/git"
-	ghclient "github.com/pixxle/codehephaestus/internal/github"
-	"github.com/pixxle/codehephaestus/internal/planning"
-	"github.com/pixxle/codehephaestus/internal/statemachine"
-	"github.com/pixxle/codehephaestus/internal/tracker"
+	"github.com/pixxle/solomon/internal/config"
+	"github.com/pixxle/solomon/internal/db"
+	"github.com/pixxle/solomon/internal/git"
+	ghclient "github.com/pixxle/solomon/internal/github"
+	"github.com/pixxle/solomon/internal/planning"
+	"github.com/pixxle/solomon/internal/statemachine"
+	"github.com/pixxle/solomon/internal/tracker"
 )
 
 const githubBotSuffix = "[bot]"

--- a/internal/planning/planner.go
+++ b/internal/planning/planner.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/pixxle/codehephaestus/internal/config"
-	"github.com/pixxle/codehephaestus/internal/db"
-	"github.com/pixxle/codehephaestus/internal/figma"
-	"github.com/pixxle/codehephaestus/internal/guardrails"
-	"github.com/pixxle/codehephaestus/internal/slack"
-	"github.com/pixxle/codehephaestus/internal/tracker"
-	"github.com/pixxle/codehephaestus/internal/worker"
+	"github.com/pixxle/solomon/internal/config"
+	"github.com/pixxle/solomon/internal/db"
+	"github.com/pixxle/solomon/internal/figma"
+	"github.com/pixxle/solomon/internal/guardrails"
+	"github.com/pixxle/solomon/internal/slack"
+	"github.com/pixxle/solomon/internal/tracker"
+	"github.com/pixxle/solomon/internal/worker"
 )
 
 // DescriptionChanged reports whether the issue description differs from the last analyzed version.
@@ -479,7 +479,7 @@ func (p *Planner) collectImages(ctx context.Context, issue tracker.Issue) ([]str
 		return nil, err
 	}
 
-	imgDir := filepath.Join(p.cfg.TargetRepoPath, ".codehephaestus", "images", issue.Key)
+	imgDir := filepath.Join(p.cfg.TargetRepoPath, ".solomon", "images", issue.Key)
 	if err := os.MkdirAll(imgDir, 0o755); err != nil {
 		return nil, err
 	}

--- a/internal/planning/planner_test.go
+++ b/internal/planning/planner_test.go
@@ -3,7 +3,7 @@ package planning
 import (
 	"testing"
 
-	"github.com/pixxle/codehephaestus/internal/db"
+	"github.com/pixxle/solomon/internal/db"
 )
 
 func TestParseQuestions(t *testing.T) {

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 	slackapi "github.com/slack-go/slack"
 
-	"github.com/pixxle/codehephaestus/internal/db"
+	"github.com/pixxle/solomon/internal/db"
 )
 
 // SlackNotifier posts threaded messages to Slack, one thread per ticket.

--- a/internal/slack/notifier.go
+++ b/internal/slack/notifier.go
@@ -5,8 +5,8 @@ import (
 
 	slackapi "github.com/slack-go/slack"
 
-	"github.com/pixxle/codehephaestus/internal/config"
-	"github.com/pixxle/codehephaestus/internal/db"
+	"github.com/pixxle/solomon/internal/config"
+	"github.com/pixxle/solomon/internal/db"
 )
 
 // Notifier sends lifecycle notifications for ticket processing.

--- a/internal/slack/standup.go
+++ b/internal/slack/standup.go
@@ -8,9 +8,9 @@ import (
 	"github.com/rs/zerolog/log"
 	slackapi "github.com/slack-go/slack"
 
-	"github.com/pixxle/codehephaestus/internal/config"
-	"github.com/pixxle/codehephaestus/internal/db"
-	"github.com/pixxle/codehephaestus/internal/worker"
+	"github.com/pixxle/solomon/internal/config"
+	"github.com/pixxle/solomon/internal/db"
+	"github.com/pixxle/solomon/internal/worker"
 )
 
 // standupItem is the JSON shape passed to the standup prompt template.

--- a/internal/statemachine/handlers.go
+++ b/internal/statemachine/handlers.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/pixxle/codehephaestus/internal/db"
-	"github.com/pixxle/codehephaestus/internal/git"
-	ghclient "github.com/pixxle/codehephaestus/internal/github"
-	"github.com/pixxle/codehephaestus/internal/guardrails"
-	"github.com/pixxle/codehephaestus/internal/team"
-	"github.com/pixxle/codehephaestus/internal/tracker"
-	"github.com/pixxle/codehephaestus/internal/worker"
+	"github.com/pixxle/solomon/internal/db"
+	"github.com/pixxle/solomon/internal/git"
+	ghclient "github.com/pixxle/solomon/internal/github"
+	"github.com/pixxle/solomon/internal/guardrails"
+	"github.com/pixxle/solomon/internal/team"
+	"github.com/pixxle/solomon/internal/tracker"
+	"github.com/pixxle/solomon/internal/worker"
 )
 
 // Handlers contains the logic for each state transition.

--- a/internal/statemachine/machine.go
+++ b/internal/statemachine/machine.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/pixxle/codehephaestus/internal/config"
-	"github.com/pixxle/codehephaestus/internal/db"
-	"github.com/pixxle/codehephaestus/internal/figma"
-	ghclient "github.com/pixxle/codehephaestus/internal/github"
-	"github.com/pixxle/codehephaestus/internal/planning"
-	"github.com/pixxle/codehephaestus/internal/slack"
-	"github.com/pixxle/codehephaestus/internal/team"
-	"github.com/pixxle/codehephaestus/internal/tracker"
+	"github.com/pixxle/solomon/internal/config"
+	"github.com/pixxle/solomon/internal/db"
+	"github.com/pixxle/solomon/internal/figma"
+	ghclient "github.com/pixxle/solomon/internal/github"
+	"github.com/pixxle/solomon/internal/planning"
+	"github.com/pixxle/solomon/internal/slack"
+	"github.com/pixxle/solomon/internal/team"
+	"github.com/pixxle/solomon/internal/tracker"
 )
 
 // Machine routes work items to the correct state handler.

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/pixxle/codehephaestus/internal/config"
-	"github.com/pixxle/codehephaestus/internal/worker"
+	"github.com/pixxle/solomon/internal/config"
+	"github.com/pixxle/solomon/internal/worker"
 )
 
 type Launcher struct {

--- a/internal/team/prompt.go
+++ b/internal/team/prompt.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pixxle/codehephaestus/internal/worker"
+	"github.com/pixxle/solomon/internal/worker"
 )
 
 type TeamLeadContext struct {

--- a/internal/tracker/jira.go
+++ b/internal/tracker/jira.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pixxle/codehephaestus/internal/config"
+	"github.com/pixxle/solomon/internal/config"
 )
 
 type JiraTracker struct {

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pixxle/codehephaestus/internal/config"
+	"github.com/pixxle/solomon/internal/config"
 )
 
 type TaskTracker interface {


### PR DESCRIPTION
## Summary
This PR renames the project from "CodeHephaestus" to "Solomon" across all source files, configuration, and documentation.

## Key Changes
- Updated project branding in README.md and documentation
- Changed Go module path from `github.com/pixxle/codehephaestus` to `github.com/pixxle/solomon`
- Updated all import statements throughout the codebase to use the new module path
- Changed default configuration values:
  - `BOT_DISPLAY_NAME`: "CodeHephaestus" → "Solomon"
  - `JIRA_PLANNING_LABEL`: "codehephaestus" → "solomon"
- Updated internal directory references from `.codehephaestus` to `.solomon` for state database and image storage
- Updated build and usage instructions to reference the new binary name `solomon`
- Updated LICENSE copyright attribution
- Updated .gitignore to exclude the new `.solomon/` directory and `solomon` binary
- Updated test cases to reflect new default values

## Implementation Details
- All Go import paths have been systematically updated to maintain consistency
- Configuration defaults in `internal/config/config.go` have been updated
- File paths for state database and image storage now use `.solomon` instead of `.codehephaestus`
- The change is purely a rename with no functional modifications to the codebase

https://claude.ai/code/session_01P1MaMMzkujZVkBPo6jG5vr